### PR TITLE
Replace sinusoidal encoding in image learning

### DIFF
--- a/mlx_nerf/__main__.py
+++ b/mlx_nerf/__main__.py
@@ -14,6 +14,6 @@ if __name__ == "__main__":
     mx.set_default_device(mx.gpu)
     tyro.cli(
         # entrypoints.viser_record3d
-        # entrypoints.viser_image_learning
-        entrypoints.test_nerf
+        entrypoints.viser_image_learning
+        # entrypoints.test_nerf
     )

--- a/mlx_nerf/encoding/identity.py
+++ b/mlx_nerf/encoding/identity.py
@@ -24,9 +24,9 @@ class IdentityEncoding(Encoding):
 
         return self.in_dim
     
-    def forward(
+    def __call__(
             self, 
             in_array: mx.array
-        ):
+    ):
 
         return in_array

--- a/mlx_nerf/encoding/sinusoidal.py
+++ b/mlx_nerf/encoding/sinusoidal.py
@@ -15,15 +15,15 @@ class SinusoidalEncoding(Encoding):
         self, 
         in_dim: int, 
         n_freqs: int, 
-        min_freq: float, 
-        max_freq: float, 
+        min_freq_exp: float, 
+        max_freq_exp: float, 
         is_include_input: bool = False, 
     ) -> None:
         super().__init__(in_dim)
 
         self.n_freqs = n_freqs
-        self.min_freq = min_freq if min_freq else 0
-        self.max_freq = max_freq if max_freq else float(n_freqs-1)
+        self.min_freq_exp = min_freq_exp if min_freq_exp else 0
+        self.max_freq_exp = max_freq_exp if max_freq_exp else float(n_freqs-1)
 
         self.is_include_input = is_include_input
         return
@@ -47,7 +47,7 @@ class SinusoidalEncoding(Encoding):
         """
 
         freq_bands = 2.0 ** mx.linspace(
-            self.min_freq, self.max_freq, num=self.n_freqs
+            self.min_freq_exp, self.max_freq_exp, num=self.n_freqs
         )
         in_array_scaled = 2.0 * mx.pi * in_array
         in_array_scaled = in_array_scaled[..., None] * freq_bands # [B, in_dim, n_freqs]

--- a/mlx_nerf/encoding/sinusoidal.py
+++ b/mlx_nerf/encoding/sinusoidal.py
@@ -15,14 +15,14 @@ class SinusoidalEncoding(Encoding):
         self, 
         in_dim: int, 
         n_freqs: int, 
-        min_freq_exp: float, 
-        max_freq_exp: float, 
+        min_freq_exp: float = None, 
+        max_freq_exp: float = None, 
         is_include_input: bool = False, 
     ) -> None:
         super().__init__(in_dim)
 
         self.n_freqs = n_freqs
-        self.min_freq_exp = min_freq_exp if min_freq_exp else 0
+        self.min_freq_exp = min_freq_exp if min_freq_exp else 0.0
         self.max_freq_exp = max_freq_exp if max_freq_exp else float(n_freqs-1)
 
         self.is_include_input = is_include_input
@@ -36,10 +36,10 @@ class SinusoidalEncoding(Encoding):
 
         return out_dim
     
-    def forward(
+    def __call__(
             self, 
             in_array: mx.array
-        ):
+    ):
         """### SinusoidalEncoding.forward
         ###### in `mlx_nerf/encoding/sinusoidal.py`
 
@@ -49,7 +49,8 @@ class SinusoidalEncoding(Encoding):
         freq_bands = 2.0 ** mx.linspace(
             self.min_freq_exp, self.max_freq_exp, num=self.n_freqs
         )
-        in_array_scaled = 2.0 * mx.pi * in_array
+        in_array_scaled = in_array
+        # in_array_scaled = 2.0 * mx.pi * in_array # NOTE: this performs worse in image training; TODO: see if the degeneration occurs in volume learning as well
         in_array_scaled = in_array_scaled[..., None] * freq_bands # [B, in_dim, n_freqs]
         in_array_scaled = mx.reshape(in_array_scaled, (in_array_scaled.shape[0], -1)) # [B, in_dim * n_freqs]
 

--- a/mlx_nerf/entrypoints/__init__.py
+++ b/mlx_nerf/entrypoints/__init__.py
@@ -2,9 +2,7 @@
 # NOTE: but intellisense might not able to recognize those modules for autosuggestion
 # NOTE: hence, do import manually
 
-from .__viser_record3d import main as viser_record3d
 from .__viser_image_learning import main as viser_image_learning
-from .__viser_gui import main as viser_gui
 from .__test_nerf import main as test_nerf
 
 # TODO: set common theme here

--- a/mlx_nerf/entrypoints/__viser_image_learning.py
+++ b/mlx_nerf/entrypoints/__viser_image_learning.py
@@ -19,6 +19,7 @@ from tqdm.auto import tqdm
 
 from this_project import get_project_root, PJ_PINK
 from mlx_nerf.models import embedding
+from mlx_nerf.encoding.sinusoidal import SinusoidalEncoding
 from mlx_nerf.models.NeRF import NeRF
 from mlx_nerf.ops.metric import MSE
 
@@ -195,7 +196,10 @@ def main(
     gui_items.img_pred = get_mx_img_pred(gui_items.img_gt.shape)
     
     N_INPUT_DIMS = 2
-    embed, out_dim = embedding.get_embedder(10, n_input_dims=N_INPUT_DIMS)
+    # embed, out_dim = embedding.get_embedder(10, n_input_dims=N_INPUT_DIMS)
+    embed = SinusoidalEncoding(N_INPUT_DIMS, 10, min_freq_exp=0.0, max_freq_exp=8.0, is_include_input=False)
+    out_dim = embed.get_out_dim()
+
 
     # NOTE: NeRF
     model = NeRF(

--- a/mlx_nerf/entrypoints/__viser_image_learning.py
+++ b/mlx_nerf/entrypoints/__viser_image_learning.py
@@ -18,7 +18,6 @@ from imageio.core.format import Format
 from tqdm.auto import tqdm
 
 from this_project import get_project_root, PJ_PINK
-from mlx_nerf.models import embedding
 from mlx_nerf.encoding.sinusoidal import SinusoidalEncoding
 from mlx_nerf.models.NeRF import NeRF
 from mlx_nerf.ops.metric import MSE
@@ -196,7 +195,6 @@ def main(
     gui_items.img_pred = get_mx_img_pred(gui_items.img_gt.shape)
     
     N_INPUT_DIMS = 2
-    # embed, out_dim = embedding.get_embedder(10, n_input_dims=N_INPUT_DIMS)
     embed = SinusoidalEncoding(N_INPUT_DIMS, 10, min_freq_exp=0.0, max_freq_exp=8.0, is_include_input=False)
     out_dim = embed.get_out_dim()
 


### PR DESCRIPTION
resolves #2 

* Scaling of input positions by 2*PI, which is suggested in Transformers [NIPS2017] and NeRF [ECCV2020], performed worse than plain input positions... 
* Scaled input introduces lattice artifact along the entire image, whereas plain input produces artifact-free estimation


`2*PI` scaled:

https://github.com/piljoong-jeong/nerf_meets_mlx/assets/43630935/204a39b7-5a0c-4c8b-b535-3f131a772754

No scaled:

https://github.com/piljoong-jeong/nerf_meets_mlx/assets/43630935/4e0e248e-24bc-4fba-95ba-d938fb552d28


